### PR TITLE
Add option to get specific key in a secret

### DIFF
--- a/secretsmanager.go
+++ b/secretsmanager.go
@@ -9,28 +9,49 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 )
 
-// New creates an AWS Session Manager Client
-func New() (*Secret, error) {
-	sess := session.Must(session.NewSession())
+// SecretsManager returns a representation of the Secrets Manager API
+func (c *Client) SecretsManager() secretsmanageriface.SecretsManagerAPI {
+	return c.api
+}
 
-	var c *aws.Config
-	s := Secret{
-		Client: secretsmanager.New(sess, c),
+// New creates an AWS Session Manager Client
+func New(config *AWSConfig) *Client {
+	c := &Client{
+		config: config,
 	}
-	return &s, nil
+
+	s := c.newSession(config)
+	c.api = secretsmanager.New(s)
+	return c
+}
+
+func (c *Client) newSession(config *AWSConfig) *session.Session {
+	// Initialize config with error verbosity
+	sess := aws.NewConfig().WithCredentialsChainVerboseErrors(true)
+
+	if config.Region != "" {
+		sess = sess.WithRegion(config.Region)
+	}
+
+	opts := session.Options{
+		Config: *sess,
+	}
+
+	return session.Must(session.NewSessionWithOptions(opts))
 }
 
 // GetSecret return an AWS Secret Manager secret
 // in plain text from a given secret name
-func (s *Secret) GetSecret(name string) (string, error) {
+func (c *Client) GetSecret(spec *SecretSpec) (string, error) {
 	params := &secretsmanager.GetSecretValueInput{
-		SecretId:     aws.String(name),
+		SecretId:     aws.String(spec.Name),
 		VersionStage: aws.String("AWSCURRENT"),
 	}
 
-	resp, err := s.Client.GetSecretValue(params)
+	resp, err := c.api.GetSecretValue(params)
 	if err != nil {
 		return "", err
 	}
@@ -40,10 +61,10 @@ func (s *Secret) GetSecret(name string) (string, error) {
 	}
 
 	secret := SecretString{
-		Name:   *resp.Name,
-		Secret: *resp.SecretString,
+		Name:         *resp.Name,
+		SecretString: *resp.SecretString,
 	}
-	value, err := getSecretValue(&secret)
+	value, err := getSecretValue(&secret, spec)
 	if err != nil {
 		return "", err
 	}
@@ -51,18 +72,26 @@ func (s *Secret) GetSecret(name string) (string, error) {
 	return value, nil
 }
 
-func getSecretValue(s *SecretString) (string, error) {
+func getSecretValue(s *SecretString, spec *SecretSpec) (string, error) {
 	var secretValue map[string]string
 
-	blob := []byte(s.Secret)
+	blob := []byte(s.SecretString)
 
 	err := json.Unmarshal(blob, &secretValue)
 	if err != nil {
 		return "", err
 	}
 
-	for _, v := range secretValue {
+	// If key is not set then return first value stored in secret
+	if spec.Key == "" {
+		for _, v := range secretValue {
+			return v, nil
+		}
+	}
+
+	if v, ok := secretValue[spec.Key]; ok {
 		return v, nil
 	}
-	return "", errors.New("Secret not found")
+
+	return "", errors.New("No secret found")
 }

--- a/secretsmanager_test.go
+++ b/secretsmanager_test.go
@@ -15,30 +15,107 @@ type mockedSecret struct {
 
 // GetSecret return mocked secret value
 func (m mockedSecret) GetSecretValue(in *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
-	// for now just return empty resp
 	return &m.Resp, nil
 }
 
 func TestGetSecret(t *testing.T) {
-	testCase := struct {
-		Resp     secretsmanager.GetSecretValueOutput
-		Expected string
+	testCases := []struct {
+		arg  *SecretSpec
+		mock secretsmanager.GetSecretValueOutput
+		want string
+		ok   bool
 	}{
-		Resp: secretsmanager.GetSecretValueOutput{
-			Name:         aws.String("test/secret"),
-			SecretString: aws.String(`{"key": "test"}`),
+		{
+			arg: &SecretSpec{Name: "test/secret"},
+			mock: secretsmanager.GetSecretValueOutput{
+				Name:         aws.String("test/secret"),
+				SecretString: aws.String(`{"key": "test"}`),
+			},
+			want: "test",
+			ok:   true,
 		},
-		Expected: "test",
+		{
+			arg: &SecretSpec{
+				Name: "test/secret",
+				Key:  "key",
+			},
+			mock: secretsmanager.GetSecretValueOutput{
+				Name:         aws.String("test/secret"),
+				SecretString: aws.String(`{"key": "test"}`),
+			},
+			want: "test",
+			ok:   true,
+		},
+		{
+			arg: &SecretSpec{
+				Name: "test/secret",
+				Key:  "second_key",
+			},
+			mock: secretsmanager.GetSecretValueOutput{
+				Name:         aws.String("test/secret"),
+				SecretString: aws.String(`{"first_key": "first_val", "second_key": "second_val"}`),
+			},
+			want: "second_val",
+			ok:   true,
+		},
+		{
+			arg: &SecretSpec{
+				Name: "test/secret",
+			},
+			mock: secretsmanager.GetSecretValueOutput{
+				Name:         aws.String("test/secret"),
+				SecretString: aws.String(`{"first_key": "first_val", "second_key": "second_val"}`),
+			},
+			want: "first_val",
+			ok:   true,
+		},
+		{
+			arg: &SecretSpec{
+				Name: "test/secret",
+				Key:  "nonexistent",
+			},
+			mock: secretsmanager.GetSecretValueOutput{
+				Name:         aws.String("test/secret"),
+				SecretString: aws.String(`{"key": "test"}`),
+			},
+			ok: false,
+		},
+		{
+			arg: &SecretSpec{
+				Name: "test/secret",
+				Key:  "nonexistent",
+			},
+			mock: secretsmanager.GetSecretValueOutput{
+				Name:         aws.String("test/secret"),
+				SecretString: aws.String(`{"first_key": "first_val", "second_key": "second_val"}`),
+			},
+			ok: false,
+		},
+		{
+			arg: &SecretSpec{
+				Name: "test/secret",
+				Key:  "nonexistent",
+			},
+			mock: secretsmanager.GetSecretValueOutput{},
+			ok:   false,
+		},
 	}
 
-	s := Secret{
-		Client: mockedSecret{Resp: testCase.Resp},
-	}
-	resp, err := s.GetSecret("test/secret")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp != testCase.Expected {
-		t.Fatalf("expected secret %v, got %v", resp, testCase.Expected)
+	for _, test := range testCases {
+		c := &Client{
+			api: mockedSecret{Resp: test.mock},
+		}
+		got, err := c.GetSecret(test.arg)
+		if test.ok {
+			if got != test.want {
+				t.Fatalf("want %v, got %v, error %v, using arg %v", test.want, got, err, test.arg)
+			}
+		}
+		if !test.ok {
+			if err == nil {
+				t.Fatalf("error expected but got %q, using arg %v", err, test.arg)
+			}
+		}
+		t.Logf("arg (%v), want %v, got %v, err %v", test.arg, test.want, got, err)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -4,15 +4,33 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 )
 
-// Secret represents an AWS Secrets Manager
-// client
-type Secret struct {
-	Client secretsmanageriface.SecretsManagerAPI
+// AWSConfig store configuration used to initialize
+// secrets manager client.
+type AWSConfig struct {
+	Region string
+}
+
+// SecretSpec represent specs of secret to be searched
+// If Key field is not set then package will return first
+// secret key stored in secret name.
+//
+// maps to ClusterConfig
+type SecretSpec struct {
+	Name string
+	Key  string
+}
+
+// Client represents an AWS Secrets Manager client
+//
+// maps to ProviderServices
+type Client struct {
+	config *AWSConfig
+	api    secretsmanageriface.SecretsManagerAPI
 }
 
 // SecretString is a concret representation
 // of an AWS Secrets Manager Secret String
 type SecretString struct {
-	Name   string
-	Secret string
+	Name         string
+	SecretString string
 }


### PR DESCRIPTION
It is possible to store multiple key/value items in a single AWS Secrets Manager secret, actual implementation only allow to fetch a single key.

This PR add the posibility to specify which key must be fetched from Secrets Manager

Fix #1 